### PR TITLE
Using CloudEvent SDK

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,6 @@ func GetConfig() config {
 		BootStrapServers: strings.ToLower(getEnv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")),
 		KafkaTopic:       os.Getenv("KAFKA_TOPIC"),
 		Target:           os.Getenv("TARGET"),
-		Host:             os.Getenv("HOST"),
 		LogLevel:         strings.ToLower(getEnv("LOG_LEVEL", "info")),
 		LogFormat:        strings.ToLower(getEnv("LOG_FORMAT", "text")), //cann be text or json
 	}


### PR DESCRIPTION
moving towards cloud events

* Did run a server (ghello:latest) on localhost, and exported the URL as target.
* connected to local kafka, and send messages via `kafkacat`

Log from the event-src:

```
2018/11/05 10:20:03 posting to "http://localhost:7000/post"
2018/11/05 10:20:03 response Status: 200 OK
2018/11/05 10:20:03 response Body: 
```

Log from `ghello`:
```
eventType: dev.knative.source.kafka 
eventType: dev.knative.source.kafka 
eventType: dev.knative.source.kafka 
```